### PR TITLE
Upgrade rpm dependency to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ quick-xml = { version = "0.23.0", default-features = false }
 # rayon = "1.5.1"
 thiserror = "1.0.40"
 niffler = { version = "2.5.0", features = ["bz2", "xz", "gz", "zstd"], default-features = false }
-rpm = { version = "0.12.0", default-features = false, optional = true }
+rpm = { version = "0.14", default-features = false, optional = true }
 # tempdir = "0.3.7"
 digest = "0.10.6"
 sha1 = "0.10.5"


### PR DESCRIPTION
Hi Daniel,

rpm@0.12.x has a dependency which doesn't seem to work on Mac. Tried some dependency patching but that didn't seem to work as I expected. I got a conflicting version request for a pgp dependency this time which stemmed from rpmrepo_metadata's dependency on rpm (I have to admit that I'm new to dependency consolidation with Cargo).

Upgrading to 0.14 seemed to work and tests were passing so thought it might be a good idea to do an upgrade here