### PR TITLE
Update to niffler 3.0.0 and rpm 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ read_rpm = ["rpm"]
 quick-xml = { version = "0.23.0", default-features = false }
 # rayon = "1.5.1"
 thiserror = "1.0.40"
-niffler = { version = "2.5.0", features = ["bz2", "xz", "gz", "zstd"], default-features = false }
-rpm = { version = "0.12.0", default-features = false, optional = true }
+niffler = "3.0.0"
+rpm = { version = "0.16.0", default-features = false, optional = true }
 # tempdir = "0.3.7"
 digest = "0.10.6"
 sha1 = "0.10.5"

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,8 +5,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::convert::TryInto;
-use std::io::{BufRead, Write};
 use std::hash::{Hash, Hasher};
+use std::io::{BufRead, Write};
 use std::os::unix::prelude::MetadataExt;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Update niffler dep to 3.0.0. Also update rpm to 0.16.0 to solve an `lzma-sys` linking issue, but a test breaks because `./tests/assets/packages/complex-package-2.3.4-5.el8.x86_64.rpm` is missing in the repo