### PR TITLE
Fix panic when RPM contains symbolic link

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -97,8 +97,12 @@ pub mod rpm_parsing {
             } else {
                 match value.mode {
                     rpm::FileMode::Dir { .. } => crate::FileType::Dir,
-                    rpm::FileMode::Regular { .. } => crate::FileType::File,
-                    _ => unreachable!("Failed to detect file type"),
+                    rpm::FileMode::Regular { .. } | rpm::FileMode::SymbolicLink { .. } => {
+                        crate::FileType::File
+                    }
+                    _ => {
+                        unreachable!("Failed to detect file type")
+                    }
                 }
             };
             let path = value

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -7,6 +7,7 @@
 extern crate rpmrepo_metadata;
 
 use pretty_assertions::assert_eq;
+use rpm::{FileMode, FileOptions, FileOptionsBuilder};
 use rpmrepo_metadata::*;
 use std::fs::OpenOptions;
 use std::io::{Cursor, Read, Seek, SeekFrom};
@@ -22,6 +23,29 @@ fn test_read_rpm_from_file() -> Result<(), MetadataError> {
     let mut pkg = utils::load_rpm_package(COMPLEX_PKG_PATH)?;
     pkg.location_href = "complex-package-2.3.4-5.el8.x86_64.rpm".to_owned();
     assert_eq!(&pkg, &*common::COMPLEX_PACKAGE);
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_rpm_with_symbolic_link() -> Result<(), MetadataError> {
+    let rpm_package = rpm::PackageBuilder::new("foo", "1.0.0", "MIT", "aarch64", "foo")
+        .with_file(
+            "./tests/assets/complex_repo_pkglist.txt",
+            FileOptions::new("/foo.txt")
+                .symlink("/bar.txt")
+                .mode(FileMode::SymbolicLink {
+                    permissions: 0o0700,
+                }),
+        )?
+        .build()?;
+    let tmp_dir = tempdir::TempDir::new("test_parse_rpm_with_symbolic_link")?;
+
+    let out = tmp_dir.path().join("out.rpm");
+
+    rpm_package.write_file(&out)?;
+
+    utils::load_rpm_package(&out.to_string_lossy())?;
 
     Ok(())
 }


### PR DESCRIPTION
When parsing a RPM that contains a symbolic link, the "unreachable" code section gets hit. This patch will address this. I am not sure if there is the possibility to add symbolic links to directories, but I think having a falsely flagged filetype is better than a panic.